### PR TITLE
ScrollPanelPatcher

### DIFF
--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/ScrollPanelPatcher.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/ScrollPanelPatcher.java
@@ -1,0 +1,20 @@
+package com.googlecode.gwt.test.internal.patchers;
+
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.UIObject;
+import com.googlecode.gwt.test.patchers.PatchClass;
+import com.googlecode.gwt.test.patchers.PatchMethod;
+
+@PatchClass(ScrollPanel.class)
+public class ScrollPanelPatcher {
+    
+    /**
+     * Simple patch to get the all test working that use ensureVisible
+     * @param scrollPanel
+     * @param item 
+     */
+    @PatchMethod
+    public static void ensureVisible(ScrollPanel scrollPanel, UIObject item) {
+
+    }
+}


### PR DESCRIPTION
The ScrollPanelPatcher allows gwt-test-utils test to use the GWT
ScrollPanel. If these tests use ensureVisible, they will work again.
