### PR TITLE
Fix UiTextTag to work with Messages

### DIFF
--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/uibinder/UiResourceManager.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/uibinder/UiResourceManager.java
@@ -380,18 +380,20 @@ class UiResourceManager {
    private static class UiTextTag implements UiTag<String> {
 
       private final UiTag<?> parentTag;
-      private final TextResource textResource;
+      private final String text;
 
       UiTextTag(Map<String, Object> attributes, UiTag<?> parentTag, Object owner) {
          this.parentTag = parentTag;
 
-         this.textResource = (TextResource) attributes.get("from");
-
-         if (textResource == null) {
+         Object value = attributes.get("from");
+         if (value instanceof TextResource) {
+            text = ((TextResource) value).getText();
+         } else if (value instanceof String) {
+            text = (String) value;
+         } else {
             throw new GwtTestUiBinderException("Error in " + owner.getClass().getSimpleName()
                      + ".ui.xml : <ui:text> tag declared without 'from' attribute");
          }
-
       }
 
       public void addElement(Element element) {
@@ -411,7 +413,7 @@ class UiResourceManager {
       }
 
       public String endTag() {
-         return textResource.getText();
+         return text;
       }
 
       public UiTag<?> getParentTag() {

--- a/gwt-test-utils/src/test/java/com/googlecode/gwt/test/uibinder/UiBinderUiText.java
+++ b/gwt-test-utils/src/test/java/com/googlecode/gwt/test/uibinder/UiBinderUiText.java
@@ -17,6 +17,9 @@ public class UiBinderUiText extends Composite {
    @UiField
    Label label;
 
+   @UiField
+   Label msgLabel;
+
    public UiBinderUiText() {
       initWidget(uiBinder.createAndBindUi(this));
    }

--- a/gwt-test-utils/src/test/java/com/googlecode/gwt/test/uibinder/UiBinderUiTextTest.java
+++ b/gwt-test-utils/src/test/java/com/googlecode/gwt/test/uibinder/UiBinderUiTextTest.java
@@ -1,6 +1,6 @@
 package com.googlecode.gwt.test.uibinder;
 
-import static com.googlecode.gwt.test.assertions.GwtAssertions.assertThat;
+import static com.googlecode.gwt.test.assertions.GwtAssertions.*;
 
 import org.junit.Test;
 
@@ -12,12 +12,14 @@ public class UiBinderUiTextTest extends GwtTestTest {
    public void checkUiText() {
       // Arrange
       String expectedText = "Hello gwt-test-utils !\r\nThis is a test with a simple text file";
+      String expectedTextFromMessages = "orange";
 
       // Act
       UiBinderUiText widget = new UiBinderUiText();
 
       // Assert
       assertThat(widget.label).textEquals(expectedText);
+      assertThat(widget.msgLabel).textEquals(expectedTextFromMessages);
    }
 
 }

--- a/gwt-test-utils/src/test/resources/com/googlecode/gwt/test/uibinder/UiBinderUiText.ui.xml
+++ b/gwt-test-utils/src/test/resources/com/googlecode/gwt/test/uibinder/UiBinderUiText.ui.xml
@@ -5,8 +5,12 @@
 	<ui:with field='res'
 		type='com.googlecode.gwt.test.resources.MyClientBundle' />
 
+	<ui:with field="msgRes"
+		type="com.googlecode.gwt.test.i18n.MyMessages"/>
+
 	<g:HTMLPanel>
 		<g:Label ui:field="label">Text : <ui:text from='{res.textResourceTxt}' /></g:Label>
+		<g:Label ui:field="msgLabel">Text : <ui:text from='{msgRes.orangeColor}' /></g:Label>
 	</g:HTMLPanel>
 
 </ui:UiBinder>


### PR DESCRIPTION
When ui:text tag 'from' attribute is used with Messags, ClassCastException happens.
