### PR TITLE
Add support for containsKey in JSONObject

### DIFF
--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/JSONObjectParser.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/JSONObjectParser.java
@@ -23,6 +23,13 @@ class JSONObjectParser {
    }
 
    @PatchMethod
+   static boolean containsKey(JSONObject jsonObject, String key) {
+      Map<String, JSONValue> map = getInnerMap(jsonObject);
+
+      return map.containsKey(key);
+   }
+
+   @PatchMethod
    static JSONValue get0(JSONObject jsonObject, String key) {
       Map<String, JSONValue> map = getInnerMap(jsonObject);
 


### PR DESCRIPTION
JSONObject don't support containsKey.

```
java.lang.UnsatisfiedLinkError: com.google.gwt.json.client.JSONObject.containsKey(Ljava/lang/String;)Z
    at com.google.gwt.json.client.JSONObject.containsKey(Native Method)
    at se.surikat.dashboard.client.JSONHelper.getJSONValueFromJSONObject(JSONHelper.java:65)
    at se.surikat.dashboard.client.JSONHelper.getJSONObjectFromJSONObject(JSONHelper.java:83)
    at se.surikat.dashboard.client.JSONHelper.getDimensionField(JSONHelper.java:13)
    at se.surikat.dashboard.client.JSONHelperTest.testGetDimensionNotAString(JSONHelperTest.java:124)
```

Have made a fix in JSONObjectParser 

```
@PatchMethod
static boolean containsKey(JSONObject jsonObject, String key) {
Map<String, JSONValue> map = getInnerMap(jsonObject);
  return map.containsKey(key);
}
```

which solves the problem
