### PR TITLE
Check gwtModules is non-empty after parsing all properties files.

### DIFF
--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/ConfigurationLoader.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/ConfigurationLoader.java
@@ -164,11 +164,6 @@ public final class ConfigurationLoader {
                      + "' : unknown value '" + value + "'");
          }
       }
-
-      if (gwtModules.size() == 0) {
-         throw new GwtTestConfigurationException(
-                  "No declared module. Did you forget to add your own META-INF/gwt-test-utils.properties file with a 'gwt-module' property in the test classpath?");
-      }
    }
 
    private void processRelatedProjectSrcDirectories(URL surefireBooterJarUrl) {
@@ -229,6 +224,11 @@ public final class ConfigurationLoader {
       } catch (IOException e) {
          throw new GwtTestConfigurationException("Error while reading '" + CONFIG_FILENAME
                   + "' files", e);
+      }
+
+      if (gwtModules.size() == 0) {
+         throw new GwtTestConfigurationException(
+                  "No declared module. Did you forget to add your own META-INF/gwt-test-utils.properties file with a 'gwt-module' property in the test classpath?");
       }
    }
 


### PR DESCRIPTION
Since the ordering of the classpath is difficult to enforce on some
build systems, the provided gwt-test-utils.properties file could be
parsed before the test one (with the gwt-module property). Only
throw the gwt-module empty exception after loading all of the
properties files.
