### PR TITLE
Update javassist, disable doclint for JDK 8 compatibiliy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.15.0-GA</version>
+				<version>3.20.0-GA</version>
 			</dependency>
 			<dependency>
 				<groupId>org.easytesting</groupId>
@@ -348,6 +348,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+                  <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>


### PR DESCRIPTION
In order to be able to use gwt-test-utils with JDK 8 I had to update javassist lest I'd hit [an exception several other folks hit as well](https://www.google.de/search?q=javassist+invalid+constant+type+15&ie=utf-8&oe=utf-8&gws_rd=cr&ei=3GXQVuDvOOqF6ATIwrm4DQ). 
Additionally, to be able to compile under JDK 8, I had to disable the doclint functionality in Javadoc (or I would have needed to fix tons of issues it flags as errors).