### PR TITLE
Issue #79 - GWT 2.8.0 support added

### DIFF
--- a/gwt-test-utils/src/main/java/com/google/gwt/dev/shell/StandardRebindOracle2.java
+++ b/gwt-test-utils/src/main/java/com/google/gwt/dev/shell/StandardRebindOracle2.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.dev.shell;
+
+import com.google.gwt.core.ext.*;
+import com.google.gwt.core.ext.linker.ArtifactSet;
+import com.google.gwt.dev.RebindCache;
+import com.google.gwt.dev.cfg.Rule;
+import com.google.gwt.dev.javac.CachedGeneratorResultImpl;
+import com.google.gwt.dev.javac.StandardGeneratorContext;
+import com.google.gwt.dev.jdt.RebindOracle;
+import com.google.gwt.dev.util.log.speedtracer.DevModeEventType;
+import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger;
+import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger.Event;
+import com.google.gwt.thirdparty.guava.common.collect.Maps;
+
+import java.util.Deque;
+import java.util.Map;
+
+/**
+ * Implements rebind logic in terms of a variety of other well-known oracles.
+ */
+public class StandardRebindOracle2 implements RebindOracle {
+
+    /**
+     * Makes the actual deferred binding decision by examining rules.
+     */
+    private final class Rebinder implements RebindRuleResolver {
+
+        @Override
+        public boolean checkRebindRuleResolvable(String typeName) {
+            try {
+                if (getRebindRule(TreeLogger.NULL, typeName) != null) {
+                    return true;
+                }
+            } catch (UnableToCompleteException utcEx) {
+            }
+            return false;
+        }
+
+        public String rebind(TreeLogger logger, String typeName, ArtifactAcceptor artifactAcceptor)
+                throws UnableToCompleteException {
+            Event rebindEvent = SpeedTracerLogger.start(DevModeEventType.REBIND, "Type Name", typeName);
+            try {
+                genCtx.setPropertyOracle(propOracle);
+                genCtx.setRebindRuleResolver(this);
+                Rule rule = getRebindRule(logger, typeName);
+
+                if (rule == null) {
+                    return typeName;
+                }
+
+                CachedGeneratorResult cachedResult = rebindCacheGet(rule, typeName);
+                if (cachedResult != null) {
+                    genCtx.setCachedGeneratorResult(cachedResult);
+                }
+
+                // realize the rule (call a generator, or do type replacement, etc.)
+                RebindResult result = rule.realize(logger, genCtx, typeName);
+
+                // handle rebind result caching (if enabled)
+                String resultTypeName =
+                        processCacheableResult(logger, rule, typeName, cachedResult, result);
+
+        /*
+         * Finalize new artifacts from the generator context
+         */
+                if (artifactAcceptor != null) {
+                    // Go ahead and call finish() to accept new artifacts.
+                    ArtifactSet newlyGeneratedArtifacts = genCtx.finish(logger);
+                    if (!newlyGeneratedArtifacts.isEmpty()) {
+                        artifactAcceptor.accept(logger, newlyGeneratedArtifacts);
+                    }
+                }
+
+                assert (resultTypeName != null);
+                return resultTypeName;
+            } finally {
+                rebindEvent.end();
+            }
+        }
+
+        private Rule getRebindRule(TreeLogger logger, String typeName) throws UnableToCompleteException {
+
+            // Make the rebind decision.
+            if (rules.isEmpty()) {
+                logger.log(TreeLogger.DEBUG, "No rules are defined, so no substitution can occur", null);
+                return null;
+            }
+
+            Rule minCostRuleSoFar = null;
+
+            for (Rule rule : rules) {
+
+                TreeLogger branch = Messages.TRACE_CHECKING_RULE.branch(logger, rule, null);
+
+                if (rule.isApplicable(branch, genCtx, typeName)) {
+                    Messages.TRACE_RULE_MATCHED.log(logger, null);
+                    return rule;
+                }
+                Messages.TRACE_RULE_DID_NOT_MATCH.log(logger, null);
+
+                // keep track of fallback partial matches
+                if (minCostRuleSoFar == null) {
+                    minCostRuleSoFar = rule;
+                }
+                assert rule.getFallbackEvaluationCost() != 0;
+                // if we found a better match, keep that as the best candidate so far
+                if (rule.getFallbackEvaluationCost() <= minCostRuleSoFar.getFallbackEvaluationCost()) {
+                    if (logger.isLoggable(TreeLogger.DEBUG)) {
+                        logger.log(TreeLogger.DEBUG, "Found better fallback match for " + rule);
+                    }
+                    minCostRuleSoFar = rule;
+                }
+            }
+
+            // if we reach this point, it means we did not find an exact match
+            // and we may have a partial match based on fall back values
+            assert minCostRuleSoFar != null;
+            if (minCostRuleSoFar.getFallbackEvaluationCost() < Integer.MAX_VALUE) {
+                if (logger.isLoggable(TreeLogger.INFO)) {
+                    logger.log(TreeLogger.INFO, "Could not find an exact match rule. Using 'closest' rule "
+                            + minCostRuleSoFar
+                            + " based on fall back values. You may need to implement a specific "
+                            + "binding in case the fall back behavior does not replace the missing binding");
+                }
+                if (logger.isLoggable(TreeLogger.DEBUG)) {
+                    logger.log(TreeLogger.DEBUG, "No exact match was found, using closest match rule "
+                            + minCostRuleSoFar);
+                }
+                return minCostRuleSoFar;
+            }
+
+            // No matching rule for this type.
+            return null;
+        }
+
+        /*
+         * Decide how to handle integrating a previously cached result, and whether
+         * to cache the new result for the future.
+         */
+        private String processCacheableResult(TreeLogger logger, Rule rule, String typeName,
+                                              CachedGeneratorResult cachedResult, RebindResult newResult) {
+
+            String resultTypeName = newResult.getResultTypeName();
+
+            if (!genCtx.isGeneratorResultCachingEnabled()) {
+                return resultTypeName;
+            }
+
+            RebindMode mode = newResult.getRebindMode();
+            switch (mode) {
+
+                case USE_EXISTING:
+                    // in this case, no newly generated or cached types are needed
+                    break;
+
+                case USE_ALL_NEW_WITH_NO_CACHING:
+          /*
+           * in this case, new artifacts have been generated, but no need to
+           * cache results (as the generator is probably not able to take
+           * advantage of caching).
+           */
+                    break;
+
+                case USE_ALL_NEW:
+                    // use all new results, add a new cache entry
+                    cachedResult =
+                            new CachedGeneratorResultImpl(newResult.getResultTypeName(), genCtx.getArtifacts(),
+                                    genCtx.getGeneratedUnitMap(), System.currentTimeMillis(), newResult
+                                    .getClientDataMap());
+                    rebindCachePut(rule, typeName, cachedResult);
+                    break;
+
+                case USE_ALL_CACHED:
+                    // use all cached results
+                    assert (cachedResult != null);
+
+                    genCtx.commitArtifactsFromCache(logger);
+                    genCtx.addGeneratedUnitsFromCache();
+
+                    // use cached type name
+                    resultTypeName = cachedResult.getResultTypeName();
+                    break;
+
+                case USE_PARTIAL_CACHED:
+          /*
+           * Add cached generated units marked for reuse to the context.
+           * TODO(jbrosenberg): add support for reusing artifacts as well as
+           * GeneratedUnits.
+           */
+                    genCtx.addGeneratedUnitsMarkedForReuseFromCache();
+
+          /*
+           * Create a new cache entry using the composite set of new and reused
+           * cached results currently in genCtx.
+           */
+                    cachedResult =
+                            new CachedGeneratorResultImpl(newResult.getResultTypeName(), genCtx.getArtifacts(),
+                                    genCtx.getGeneratedUnitMap(), System.currentTimeMillis(), newResult
+                                    .getClientDataMap());
+                    rebindCachePut(rule, typeName, cachedResult);
+                    break;
+            }
+
+            // clear the current cached result
+            genCtx.setCachedGeneratorResult(null);
+
+            return resultTypeName;
+        }
+    }
+
+    private final Map<String, String> typeNameBindingMap = Maps.newHashMap();
+
+    private final StandardGeneratorContext genCtx;
+
+    private final PropertyOracle propOracle;
+
+    private RebindCache rebindCache = null;
+
+    private final Deque<Rule> rules;
+
+    public StandardRebindOracle2(PropertyOracle propOracle, Deque<Rule> rules,
+                                 StandardGeneratorContext genCtx) {
+        this.propOracle = propOracle;
+        this.rules = rules;
+        this.genCtx = genCtx;
+    }
+
+    @Override
+    public String rebind(TreeLogger logger, String typeName) throws UnableToCompleteException {
+        return rebind(logger, typeName, null);
+    }
+
+  public void invalidateRebind(String sourceTypeName) {
+    typeNameBindingMap.remove(sourceTypeName);
+  }
+
+    public String rebind(TreeLogger logger, String typeName, ArtifactAcceptor artifactAcceptor)
+            throws UnableToCompleteException {
+
+        String resultTypeName = typeNameBindingMap.get(typeName);
+        if (resultTypeName == null) {
+            logger = Messages.TRACE_TOPLEVEL_REBIND.branch(logger, typeName, null);
+
+            Rebinder rebinder = new Rebinder();
+            resultTypeName = rebinder.rebind(logger, typeName, artifactAcceptor);
+            typeNameBindingMap.put(typeName, resultTypeName);
+
+            Messages.TRACE_TOPLEVEL_REBIND_RESULT.log(logger, resultTypeName, null);
+        }
+        return resultTypeName;
+    }
+
+    public void setRebindCache(RebindCache cache) {
+        this.rebindCache = cache;
+    }
+
+    private CachedGeneratorResult rebindCacheGet(Rule rule, String typeName) {
+        if (rebindCache != null) {
+            return rebindCache.get(rule, typeName);
+        }
+        return null;
+    }
+
+    private void rebindCachePut(Rule rule, String typeName, CachedGeneratorResult result) {
+        if (rebindCache != null) {
+            rebindCache.put(rule, typeName, result);
+        }
+    }
+}

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtFactory.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtFactory.java
@@ -150,7 +150,7 @@ public class GwtFactory {
                                       CompilerContext compilerContext) throws UnableToCompleteException {
         List<String> gwtModules = configurationLoader.getGwtModules();
         String[] inherits = gwtModules.toArray(new String[gwtModules.size()]);
-        return ModuleDefLoader.createSyntheticModule(GwtTreeLogger.get(), compilerContext,
+        return ModuleDefLoader.createSyntheticModule(GwtTreeLogger.get(),
                 "com.googlecode.gwt.test.Aggregator", inherits, false);
     }
 

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/handlers/GeneratorCreateHandler.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/handlers/GeneratorCreateHandler.java
@@ -23,7 +23,7 @@ import com.google.gwt.dev.RebindCache;
 import com.google.gwt.dev.cfg.BindingProperty;
 import com.google.gwt.dev.cfg.ConfigurationProperty;
 import com.google.gwt.dev.cfg.ModuleDef;
-import com.google.gwt.dev.cfg.PropertyPermutations;
+import com.google.gwt.dev.cfg.PropertyCombinations;
 import com.google.gwt.dev.javac.CompilationState;
 import com.google.gwt.dev.javac.CompiledClass;
 import com.google.gwt.dev.javac.JsniMethod;
@@ -100,7 +100,7 @@ public class GeneratorCreateHandler implements GwtCreateHandler {
 
     protected PropertyOracle getPropertyOracle() {
         if (propertyOracle == null) {
-            PropertyPermutations permutations = new PropertyPermutations(moduleDef.getProperties(),
+            PropertyCombinations permutations = new PropertyCombinations(moduleDef.getProperties(),
                     moduleDef.getActiveLinkerNames());
 
             SortedSet<ConfigurationProperty> configPropSet = moduleDef.getProperties().getConfigurationProperties();

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/handlers/GwtTestModuleSpaceHost.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/handlers/GwtTestModuleSpaceHost.java
@@ -7,7 +7,7 @@ import com.google.gwt.dev.CompilerContext;
 import com.google.gwt.dev.PrecompileTaskOptionsImpl;
 import com.google.gwt.dev.RebindCache;
 import com.google.gwt.dev.cfg.ModuleDef;
-import com.google.gwt.dev.cfg.Rules;
+import com.google.gwt.dev.cfg.Rule;
 import com.google.gwt.dev.javac.CompilationState;
 import com.google.gwt.dev.javac.StandardGeneratorContext;
 import com.google.gwt.dev.shell.*;
@@ -16,6 +16,7 @@ import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger;
 import com.google.gwt.dev.util.log.speedtracer.SpeedTracerLogger.Event;
 
 import java.io.File;
+import java.util.Deque;
 
 /**
  * Provides an environment for a {@link com.google.gwt.dev.shell.ModuleSpace} that works
@@ -39,7 +40,7 @@ class GwtTestModuleSpaceHost implements ModuleSpaceHost {
 
     private final RebindCache rebindCache;
 
-    private StandardRebindOracle rebindOracle;
+    private StandardRebindOracle2 rebindOracle;
 
     private ModuleSpace space;
 
@@ -91,7 +92,7 @@ class GwtTestModuleSpaceHost implements ModuleSpaceHost {
             // Set up the rebind oracle for the module.
             // It has to wait until now because we need to inject javascript.
             //
-            Rules rules = module.getRules();
+            Deque<Rule> rules = module.getRules();
             PrecompileTaskOptionsImpl options = new PrecompileTaskOptionsImpl();
             options.setGenDir(genDir);
             CompilerContext compilerContext = new CompilerContext.Builder().module(module).options(
@@ -102,7 +103,7 @@ class GwtTestModuleSpaceHost implements ModuleSpaceHost {
             // Only enable generator result caching if we have a valid rebindCache
             genCtx.setGeneratorResultCachingEnabled(rebindCache != null);
 
-            rebindOracle = new StandardRebindOracle(propOracle, rules, genCtx);
+            rebindOracle = new StandardRebindOracle2(propOracle, rules, genCtx);
             rebindOracle.setRebindCache(rebindCache);
         } finally {
             moduleSpaceHostReadyEvent.end();

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/HistoryTokenEncoderPatcher.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/HistoryTokenEncoderPatcher.java
@@ -1,0 +1,21 @@
+package com.googlecode.gwt.test.internal.patchers;
+
+import com.googlecode.gwt.test.patchers.PatchClass;
+import com.googlecode.gwt.test.patchers.PatchMethod;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+@PatchClass(target = "com.google.gwt.user.client.History$HistoryTokenEncoder")
+public class HistoryTokenEncoderPatcher {
+
+  @PatchMethod
+  static String encode(Object encoder, String input) {
+    return URLEncoder.encode(input);
+  }
+
+  @PatchMethod
+  static String decode(Object encoder, String input) {
+    return URLDecoder.decode(input);
+  }
+}

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/JavaScriptObjectPatcher.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/patchers/JavaScriptObjectPatcher.java
@@ -64,6 +64,16 @@ class JavaScriptObjectPatcher {
 
     }
 
+    @PatchMethod
+    static boolean equals(JavaScriptObject jso, Object obj) {
+        return System.identityHashCode(jso) == System.identityHashCode(obj);
+    }
+
+    @PatchMethod
+    static int hashCode(JavaScriptObject jso) {
+        return System.identityHashCode(jso);
+    }
+
     private static String documentToString(Document document) {
         StringBuilder html = new StringBuilder();
         NodeList<Node> childs = document.getChildNodes();

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/resources/ClientBundleProxyFactory.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/resources/ClientBundleProxyFactory.java
@@ -113,8 +113,15 @@ class ClientBundleProxyFactory {
         }
 
         private String[] getResourceDefaultExtensions(Method method) {
-            DefaultExtensions annotation = method.getReturnType().getAnnotation(
+            Class<?> returnType = method.getReturnType();
+            DefaultExtensions annotation = returnType.getAnnotation(
                     DefaultExtensions.class);
+            
+            for (; annotation == null && returnType.getInterfaces().length > 0; returnType = returnType.getInterfaces()[0]) {
+                annotation = returnType.getAnnotation(
+                        DefaultExtensions.class);
+            }
+            
             if (annotation == null) {
                 throw new GwtTestResourcesException(
                         method.getReturnType().getSimpleName()

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     </modules>
     <properties>
         <encoding>UTF-8</encoding>
-        <gwt.version>2.7.0</gwt.version>
+        <gwt.version>2.8.0</gwt.version>
         <java.version>1.7</java.version>
         <spring.version>4.3.0.RELEASE</spring.version>
         <guice.version>4.1.0</guice.version>


### PR DESCRIPTION
**This are the changes to make gwt-test-utils compatible to GWT 2.8.0.**

I did not check this, but according to the changes I assume that GWT 2.7 will not work with this version.

In GWT 2.8 the `StandardRebindOracle` lost the `invalidateRebind` method, therefore I added a copy of that class and added the method again. Because a private field is accessed within this method, this was the simplest way to get it working. 

Please check my additions to the `JavaScriptObjectPatcher`. The unit tests are working, but I'm a bit unsure about the side effects. Because you have a deeper knowledge of your lib there may be another way to solve this.