### PR TITLE
Issue #87 - fixes invalid path exception

### DIFF
--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtFactory.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtFactory.java
@@ -1,5 +1,7 @@
 package com.googlecode.gwt.test.internal;
 
+import static com.google.gwt.thirdparty.guava.common.base.StandardSystemProperty.JAVA_CLASS_PATH;
+
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
@@ -23,10 +25,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static com.google.gwt.thirdparty.guava.common.base.StandardSystemProperty.JAVA_CLASS_PATH;
 
 
 /**
@@ -166,8 +167,24 @@ public class GwtFactory {
                 "com.googlecode.gwt.test.Aggregator", inherits, false);
     }
 
+    /**
+     * fetches absolute path from URL object.
+     *
+     * @param url
+     *          the URL object we like to get the
+     * @return the absolute path from the given URL, or null if not possible
+     */
+    private String getAbsPathFromUrl(URL url) {
+        try {
+            File nf = new File(url.toURI());
+            return nf.getAbsolutePath();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
     private void addToClassPath(URL[] srcUrls) {
-        String additionalClassPath = String.join(File.pathSeparator, Arrays.stream(srcUrls).map(URL::getPath).collect(Collectors.toList()));
+        String additionalClassPath = Arrays.stream(srcUrls).map(this::getAbsPathFromUrl).filter(Objects::nonNull).collect(Collectors.joining(File.pathSeparator));
         System.setProperty(JAVA_CLASS_PATH.key(), String.join(File.pathSeparator, new String[]{JAVA_CLASS_PATH.value(), additionalClassPath}));
     }
 


### PR DESCRIPTION
This fixes the issue #87. There is a major problem with gwt-test-utils and windows because the paths are added incorrectly to the class path. In Unix-like systems this is working by accident, but on windows the hard drive letter in the path leads to an invalid classpath. 

The fix uses the absolute path and so the leading separator is removed automatically from Java. Because of exception handling during stream processing it makes more sense to encapsulate the whole conversion. 
