### PR TITLE
"Nodelist with generic" bug

### DIFF
--- a/gwt-test-utils-csv/src/test/java/com/googlecode/gwt/test/csv/runner/CsvRunnerTest.java
+++ b/gwt-test-utils-csv/src/test/java/com/googlecode/gwt/test/csv/runner/CsvRunnerTest.java
@@ -194,26 +194,26 @@ public class CsvRunnerTest {
     @Test
     public void getInList() {
         SimiliWidgetContainer root = getList();
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/widget(2)"))).isSameAs(root.getWidget().list.get(2));
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/widget[label=child3]"))).isSameAs(root.getWidget().list.get(2));
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/widget[getLabel=child3]"))).isSameAs(root.getWidget().list.get(2));
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/widget[id=child3Id]"))).isSameAs(root.getWidget().list.get(2));
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/list[id=child3Id]"))).isSameAs(root.getWidget().list.get(2));
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/getCurrentlist[id=child3Id]"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/widget(2)"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/widget[label=child3]"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/widget[getLabel=child3]"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/widget[id=child3Id]"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/list[id=child3Id]"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/getCurrentlist[id=child3Id]"))).isSameAs(root.getWidget().list.get(2));
     }
 
     @Test
     public void getInListRecurse() {
         SimiliWidgetContainer root = getList();
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/widget[label/toString=child3]"))).isSameAs(root.getWidget().list.get(2));
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/widget[labelWithParam(a)/toString=child3]"))).isSameAs(root.getWidget().list.get(2));
-        assertThat(runner.<Widget>getNodeValue(root, Node.parse("/widget/widget[label/toString=child3]/id"))).isSameAs(root.getWidget().list.get(2).id);
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/widget[label/toString=child3]"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<SimiliWidget>getNodeValue(root, Node.parse("/widget/widget[labelWithParam(a)/toString=child3]"))).isSameAs(root.getWidget().list.get(2));
+        assertThat(runner.<String>getNodeValue(root, Node.parse("/widget/widget[label/toString=child3]/id"))).isSameAs(root.getWidget().list.get(2).id);
     }
 
     @Test
     public void getMap() {
-        assertThat(runner.<Widget>getNodeValue(o, Node.parse("/map[a]"))).isEqualTo("b");
-        assertThat(runner.<Widget>getNodeValue(o, Node.parse("/map[c]"))).isEqualTo("d");
+        assertThat(runner.<String>getNodeValue(o, Node.parse("/map[a]"))).isEqualTo("b");
+        assertThat(runner.<String>getNodeValue(o, Node.parse("/map[c]"))).isEqualTo("d");
     }
 
     @Test

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/gin/DeferredBindingModule.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/gin/DeferredBindingModule.java
@@ -6,6 +6,7 @@ import com.google.gwt.inject.client.Ginjector;
 import com.google.gwt.inject.rebind.reflect.ReflectUtil;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.*;
+import com.google.inject.Module;
 import com.google.inject.spi.*;
 import com.googlecode.gwt.test.exceptions.GwtTestPatchException;
 import com.googlecode.gwt.test.internal.GwtClassPool;

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/ClassVisibilityModifier.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/ClassVisibilityModifier.java
@@ -2,6 +2,10 @@ package com.googlecode.gwt.test.internal;
 
 import javassist.CtClass;
 import javassist.Modifier;
+import javassist.NotFoundException;
+import javassist.bytecode.AccessFlag;
+import javassist.bytecode.ClassFile;
+import javassist.bytecode.InnerClassesAttribute;
 
 /**
  * A {@link JavaClassModifier} which makes all classes public. This can be usefull for mocking
@@ -12,11 +16,38 @@ import javassist.Modifier;
 class ClassVisibilityModifier implements JavaClassModifier {
 
     public void modify(CtClass classToModify) throws Exception {
-        int modifiers = classToModify.getModifiers();
-        if (!Modifier.isPublic(modifiers)) {
-            classToModify.setModifiers(modifiers + Modifier.PUBLIC);
+    	setPublic(classToModify, false);
+    }
+    
+    public static void setPublic(CtClass classToModify, boolean replaceAll) {
+    	
+    	int modifiers = classToModify.getModifiers();
+        if ((replaceAll && Modifier.PUBLIC != modifiers) || !Modifier.isPublic(modifiers)) {
+        	
+        	CtClass outerClass = getDeclaringClass(classToModify);
+        	
+        	boolean wasFrozen = outerClass != null && outerClass.isFrozen();
+        	if (wasFrozen) {
+        		outerClass.defrost();
+        	}
+        	
+        	try {
+        		classToModify.setModifiers(replaceAll ? Modifier.PUBLIC : modifiers + Modifier.PUBLIC);
+        	} finally {
+        		if (wasFrozen) {
+        			outerClass.freeze();
+        		}
+        	}
         }
-
+    }
+    
+    public static CtClass getDeclaringClass(CtClass clazz) {
+         try {
+             return clazz.getDeclaringClass();
+         }
+         catch (NotFoundException e) {
+             return null;
+         }
     }
 
 }

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/CompilationStateClassLoader.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/CompilationStateClassLoader.java
@@ -44,11 +44,7 @@ class CompilationStateClassLoader extends Loader {
 
             CtClass ctClass = pool.get(classname);
 
-            int modifiers = ctClass.getModifiers();
-            if (!Modifier.isPublic(modifiers)) {
-                ctClass.setModifiers(modifiers + Modifier.PUBLIC);
-            }
-
+            ClassVisibilityModifier.setPublic(ctClass, false);
         }
 
         public void start(ClassPool pool) throws NotFoundException, CannotCompileException {
@@ -65,6 +61,7 @@ class CompilationStateClassLoader extends Loader {
         for (String delegate : configurationLoader.getDelegates()) {
             delegateLoadingOf(delegate);
         }
+        delegateLoadingOf("jdk.internal.reflect.");
 
         try {
             addTranslator(cp, new MakeClassPublicTranslator());

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtClassLoader.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtClassLoader.java
@@ -1,5 +1,11 @@
 package com.googlecode.gwt.test.internal;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.ProtectionDomain;
+import java.util.regex.Pattern;
+
 import com.google.gwt.dev.javac.CompilationState;
 import com.google.gwt.dev.javac.CompiledClass;
 import com.google.gwt.dev.shell.JsValueGlue;
@@ -8,16 +14,13 @@ import com.googlecode.gwt.test.GwtTest;
 import com.googlecode.gwt.test.exceptions.GwtTestException;
 import com.googlecode.gwt.test.exceptions.GwtTestPatchException;
 import com.googlecode.gwt.test.internal.rewrite.OverlayTypesRewriter;
-import com.googlecode.gwt.test.utils.GwtReflectionUtils;
-import javassist.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.security.ProtectionDomain;
-import java.util.Arrays;
-import java.util.regex.Pattern;
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.Loader;
+import javassist.NotFoundException;
+import javassist.Translator;
 
 /**
  * <p>
@@ -138,6 +141,7 @@ public class GwtClassLoader extends Loader {
 
 
         StringBuilder sb = new StringBuilder("^(");
+        sb = appendPackageToDelegate(sb, "jdk.internal.reflect.");
         sb = appendPackageToDelegate(sb, "java.");
         sb = appendPackageToDelegate(sb, "javax.");
         sb = appendPackageToDelegate(sb, "sun.");

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtFactory.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtFactory.java
@@ -1,5 +1,7 @@
 package com.googlecode.gwt.test.internal;
 
+import static com.google.gwt.thirdparty.guava.common.base.StandardSystemProperty.JAVA_CLASS_PATH;
+
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.core.ext.typeinfo.JClassType;
@@ -23,10 +25,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static com.google.gwt.thirdparty.guava.common.base.StandardSystemProperty.JAVA_CLASS_PATH;
 
 
 /**
@@ -166,8 +167,24 @@ public class GwtFactory {
                 "com.googlecode.gwt.test.Aggregator", inherits, false);
     }
 
+    /**
+     * fetches absolute path from URL object.
+     *
+     * @param url
+     *          the URL object we like to get the
+     * @return the absolute path from the given URL, or null if not possible
+     */
+    private String getAbsPathFromUrl(URL url) {
+        try {
+            File nf = new File(url.toURI());
+            return nf.getAbsolutePath();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
     private void addToClassPath(URL[] srcUrls) {
-        String additionalClassPath = String.join(File.pathSeparator, Arrays.stream(srcUrls).map(URL::getPath).collect(Collectors.toList()));
+        String additionalClassPath = Arrays.stream(srcUrls).map(this::getAbsPathFromUrl).filter(Objects::nonNull).collect(Collectors.joining(File.pathSeparator));
         System.setProperty(JAVA_CLASS_PATH.key(), String.join(File.pathSeparator, new String[]{JAVA_CLASS_PATH.value(), additionalClassPath}));
     }
 

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtPatcherUtils.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/GwtPatcherUtils.java
@@ -15,7 +15,7 @@ import javassist.Modifier;
 public class GwtPatcherUtils {
 
     public static void patch(CtClass c, Patcher patcher) throws Exception {
-        c.setModifiers(Modifier.PUBLIC);
+        ClassVisibilityModifier.setPublic(c, true);
 
         if (patcher != null) {
             patcher.initClass(c);

--- a/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/utils/GwtPropertiesHelper.java
+++ b/gwt-test-utils/src/main/java/com/googlecode/gwt/test/internal/utils/GwtPropertiesHelper.java
@@ -203,7 +203,7 @@ public class GwtPropertiesHelper implements AfterTestCallback {
             return cachedProperties.get(path);
         }
         String propertiesNameFile = "/" + path + ".properties";
-        InputStream inputStream = path.getClass().getResourceAsStream(propertiesNameFile);
+        InputStream inputStream = this.getClass().getResourceAsStream(propertiesNameFile);
         if (inputStream == null) {
             cachedProperties.put(path, null);
             return null;

--- a/gwt-test-utils/src/test/java/com/googlecode/gwt/test/MockitoNodeListGwtTest.java
+++ b/gwt-test-utils/src/test/java/com/googlecode/gwt/test/MockitoNodeListGwtTest.java
@@ -1,0 +1,52 @@
+package com.googlecode.gwt.test;
+
+import com.google.gwt.dom.client.Node;
+import com.google.gwt.dom.client.NodeList;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@GwtModule("com.googlecode.gwt.test.GwtTestUtils")
+public class MockitoNodeListGwtTest extends GwtTestWithMockito {
+
+  /**
+   * We create a mock object of a class with a method that uses NodeList as parameter.
+   *
+   * The NodeList has NO generic parameter and we expect the Test to succeed.
+   */
+  @Test
+  public void noGenericsTest() {
+    NodeListNoGenericsContainer container = Mockito.mock(NodeListNoGenericsContainer.class);
+    assertThat(container).isNotNull();
+  }
+
+  /**
+   * We create a mock object of a class with a method that uses NodeList as parameter.
+   *
+   * The NodeList HAS a generic parameter and we expect the Test to succeed, but atm it fails.
+   * Only the generic parameter of NodeList is the problem.
+   */
+  @Test
+  public void withGenericsTest() {
+    NodeListWithGenericsContainer container = Mockito.mock(NodeListWithGenericsContainer.class);
+    assertThat(container).isNotNull();
+  }
+
+  private class NodeListWithGenericsContainer {
+
+    public int length(NodeList<Node> list) {
+      return list.getLength();
+    }
+
+  }
+
+  private class NodeListNoGenericsContainer {
+
+    public int length(NodeList list) {
+      return list.getLength();
+    }
+
+  }
+
+}

--- a/gwt-test-utils/src/test/java/com/googlecode/gwt/test/i18n/MyMessagesTest.java
+++ b/gwt-test-utils/src/test/java/com/googlecode/gwt/test/i18n/MyMessagesTest.java
@@ -89,7 +89,7 @@ public class MyMessagesTest extends GwtTestTest {
         totalAmount = messages.totalAmount(6);
 
         // Then 2
-        assertThat(totalAmount).isEqualTo("Le total de votre panier est de 6,00 €");
+        assertThat(totalAmount).isEqualTo("Le total de votre panier est de 6,00\u00A0€");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.21.0-GA</version>
+                <version>3.24.1-GA</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
The PR shows how to reproduce this bug. Only the last commit is relevant, the other ones are already submitted, but not merged by @Gael 😞 

_The problem can be described like this:_
You have in your project a class that you have to mock for some reason and this class has a method with a `NodeList` as input parameter. The `NodeList` may have a generic parameter. If the method in your class has the generic type in its signature, the complete class cannot be mocked. 
If you remove the generic type from the `NodeList` parameter everything is fine and runs.

In this test case, I used the `Mockito#mock()`, but this behaviour can be seen on the `@Mock` annotation, too.

I'm afraid this can also be a problem for other classes, so we should fix this. I try to work on this, but maybe someone else has the same problem and may join to solve it. 😄 