### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/gwt-test-utils-csv/pom.xml
+++ b/gwt-test-utils-csv/pom.xml
@@ -18,21 +18,13 @@
             <artifactId>gwt-user</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-servlet</artifactId>
-            <scope>provided</scope>
-        </dependency>
+        
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-servlet</artifactId>
-            <scope>provided</scope>
-        </dependency>
+        
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
@@ -43,15 +35,7 @@
             <artifactId>spring-test</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
+        
     </dependencies>
 </project>

--- a/gwt-test-utils/pom.xml
+++ b/gwt-test-utils/pom.xml
@@ -52,37 +52,21 @@
             <artifactId>gwt-user</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-servlet</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava-gwt</artifactId>
-            <scope>provided</scope>
-        </dependency>
+        
+        
         <dependency>
             <groupId>org.jukito</groupId>
             <artifactId>jukito</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
+        
         <dependency>
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
             <scope>provided</scope>
         </dependency>
         <!-- needed by AutoBean -->
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <scope>provided</scope>
-        </dependency>
+        
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.0</version>
+                <configuration>
+                	<parallel>classes</parallel>
+                	<useUnlimitedThreads>true</useUnlimitedThreads>
+                </configuration>
+
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -299,6 +304,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Xmx512M</argLine>
+                	<parallel>classes</parallel>
+                	<useUnlimitedThreads>true</useUnlimitedThreads>
+
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
gwt-test-utils-parent
gwt-test-utils
{groupId='com.google.gwt', artifactId='gwt-servlet'}
{groupId='com.google.guava', artifactId='guava-gwt'}
{groupId='com.google.code.findbugs', artifactId='jsr305'}
{groupId='org.json', artifactId='json'}
{groupId='org.slf4j', artifactId='slf4j-simple'}
gwt-test-utils-csv
{groupId='com.google.gwt', artifactId='gwt-servlet'}
{groupId='com.google.inject.extensions', artifactId='guice-servlet'}
{groupId='org.easymock', artifactId='easymock'}
{groupId='org.mockito', artifactId='mockito-core'}
{groupId='org.slf4j', artifactId='slf4j-simple'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
